### PR TITLE
[HOTFIX] chore: Fix lru_cache import statement..

### DIFF
--- a/rest_jwt_permission/providers/admin.py
+++ b/rest_jwt_permission/providers/admin.py
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
-from django.utils.lru_cache import lru_cache
+import django
+
+if django.VERSION < (3, 0):
+    from django.utils.lru_cache import lru_cache
+else:
+    from functools import lru_cache
+
 from django.utils.translation import ugettext_lazy as _
 
 from .base import ScopeProviderBase

--- a/rest_jwt_permission/providers/utils.py
+++ b/rest_jwt_permission/providers/utils.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from django.utils import module_loading
-from django.utils.lru_cache import lru_cache
+if django.VERSION < (3, 0):
+    from django.utils.lru_cache import lru_cache
+else:
+    from functools import lru_cache
 
 from rest_jwt_permission.settings import get_setting
 


### PR DESCRIPTION
When I run `python manage.py show_roles` I get `ModuleNotFoundError: No module named 'django.utils.lru_cache'`. This fix is similar to what crispy forms are doing for retro compatibility.

Original PR:

https://github.com/django-crispy-forms/django-crispy-forms/blob/23364c25fcd0c47fa8b0dd15f3054772eae7466e/crispy_forms/compatibility.py

Haven't tested it though, but the solution should be a long the lines.